### PR TITLE
Fix mis-reverted change regarding group r's links

### DIFF
--- a/repositories.py
+++ b/repositories.py
@@ -115,7 +115,7 @@ GROUP_REPOS = [
         "group r",
         "Rhododevdron",
         ["https://github.com/Devops-2022-Group-R/itu-minitwit", "https://github.com/Devops-2022-Group-R/itu-minitwit-frontend"],
-        "<minitwit_url>",
-        "<minitwit_api_url>",
+        "http://rhododevdron.swuwu.dk",
+        "http://api.rhododevdron.swuwu.dk",
     ],
 ]


### PR DESCRIPTION
Teams message for context:
> Helge Pfeiffer It seems that our PR ([#191](https://github.com/itu-devops/lecture_notes/pull/191)) was not merged correctly due to a conflict with another PR, which reverted the changes (it seems that the issue happened when merging [#185](https://github.com/itu-devops/lecture_notes/pull/185)). I have created a PR ([#196](https://github.com/itu-devops/lecture_notes/pull/196)) that fixes this.