### PR TITLE
Update Group R's links with HTTPS

### DIFF
--- a/repositories.py
+++ b/repositories.py
@@ -115,7 +115,7 @@ GROUP_REPOS = [
         "group r",
         "Rhododevdron",
         ["https://github.com/Devops-2022-Group-R/itu-minitwit", "https://github.com/Devops-2022-Group-R/itu-minitwit-frontend"],
-        "http://rhododevdron.swuwu.dk",
-        "http://api.rhododevdron.swuwu.dk",
+        "https://rhododevdron.swuwu.dk",
+        "https://api.rhododevdron.swuwu.dk",
     ],
 ]


### PR DESCRIPTION
We have forced HTTPS on our API, and we redirect HTTP requests to our corresponding HTTPS endpoint. Though, it seems that some unexpected things happen when running the simulator against HTTP. This PR changes our URLs to HTTPS, which should fix that.