### PR TITLE
Update urls after Kubernetes switch

### DIFF
--- a/misc_urls.py
+++ b/misc_urls.py
@@ -227,7 +227,7 @@ GROUP_URLS = [
         "group r",
         "Rhododevdron",
         # Monitoring URL:
-        "http://monitoring.rhododevron.swuwu.dk",
+        "https://monitoring.rhododevdron.dk",
         # Security report URL:
         "<security_report_url>",
         # Logging URL:

--- a/repositories.py
+++ b/repositories.py
@@ -115,7 +115,7 @@ GROUP_REPOS = [
         "group r",
         "Rhododevdron",
         ["https://github.com/Devops-2022-Group-R/itu-minitwit", "https://github.com/Devops-2022-Group-R/itu-minitwit-frontend"],
-        "https://rhododevdron.swuwu.dk",
-        "https://api.rhododevdron.swuwu.dk",
+        "https://rhododevdron.dk",
+        "https://api.rhododevdron.dk",
     ],
 ]

--- a/repositories.py
+++ b/repositories.py
@@ -114,7 +114,7 @@ GROUP_REPOS = [
     [
         "group r",
         "Rhododevdron",
-        ["https://github.com/Devops-2022-Group-R/itu-minitwit", "https://github.com/Devops-2022-Group-R/itu-minitwit-frontend"],
+        ["https://github.com/Devops-2022-Group-R/itu-minitwit", "https://github.com/Devops-2022-Group-R/itu-minitwit-frontend", "https://github.com/Devops-2022-Group-R/flag-tool", "https://github.com/Devops-2022-Group-R/bump-tool"],
         "https://rhododevdron.dk",
         "https://api.rhododevdron.dk",
     ],


### PR DESCRIPTION
We recently switched hosting method to Kubernetes, requiring us to switch urls, so here are the updated ones