### PR TITLE
Add misc URLs for Group R

### DIFF
--- a/misc_urls.py
+++ b/misc_urls.py
@@ -229,11 +229,11 @@ GROUP_URLS = [
         # Monitoring URL:
         "http://monitoring.rhododevron.swuwu.dk",
         # Security report URL:
-        "<security_report_url>",
+        "https://github.com/Devops-2022-Group-R/itu-minitwit/blob/master/notes/session09_Security.md",
         # Logging URL:
-        "<logging_url>",
+        "https://logs.rhododevdron.dk",
         # SLA:
-        "<sla_url>",
+        "https://github.com/Devops-2022-Group-R/itu-minitwit/blob/master/SLA.md",
         # SLA Review:
         "<sla_review_url>",
     ],


### PR DESCRIPTION
- Security report URL
- Logging URL
- SLA URL

Note: some of the PRs that add these URLs have not been merged at the time of writing, so perhaps some links show a 404.