### PR TITLE
Group M exam hand in

### DIFF
--- a/final_report_urls.py
+++ b/final_report_urls.py
@@ -75,7 +75,7 @@ REPORT_URLS = [
         "group m",
         "DeadlyDevOps",
         # Report Release URL:
-        "https://github.com/<TBA>/<TBA>.zip",
+        "https://github.com/JesperRusbjerg/minitwit_BE/releases/tag/v1.0.1",
     ],
     [
         "group n",


### PR DESCRIPTION
We have handed in a link to the latest release

The report is generated through a github action and added to the release, each time a commit is pushed with a release tag through github actions.. This is why we have handed in a link to the release instead of just a .zip file.