### PR TITLE
Group e

### DIFF
--- a/repositories.py
+++ b/repositories.py
@@ -29,8 +29,8 @@ GROUP_REPOS = [
     ],
     [
         "group e",
-        "<Name>",
-        ["https://github.com/<organization|user>/<repository_name>"],
+        "Grl Pwr",
+        ["https://github.com/devops2024-group-e/itu-minitwit"],
         "http(s)://<TBA>/<FrontEndURL>",
         "http(s)://<TBA>/<APIURL>",
     ],


### PR DESCRIPTION
We have added our group name and repository url of group e to the `repositories.py`