### PR TITLE
Fix group table in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -312,7 +312,7 @@ TBA
 
 |BSc
 |group l
-Baglinjen",
+|Baglinjen",
 |`anbc`, `vilg`, `maraa`, `lupa`, `mbrh`
 |Ruby, Sinatra
 


### PR DESCRIPTION
A group had forgotten a "|" in front of their group name. Added "|" and it fixed the table to show correct values for all groups.