### PR TITLE
group L: changed repo to our new organisation repo

### DIFF
--- a/repositories.py
+++ b/repositories.py
@@ -72,7 +72,7 @@ GROUP_REPOS = [
     [
         "group l",
         "the happy group",
-        ["https://github.com/DumbDane/DevOps-2025"],
+        ["https://github.com/Only-Smiles/DevOps-2025"],
         "http://139.59.204.182:4567",
         "http://139.59.204.182:4567/api",
     ],


### PR DESCRIPTION
We decided to change our repository from a private user repository to a organisation repository, because we experienced that it was a huge block'er that only one developer was able to change the repository settings. 