### PR TITLE
Updated group g API url

### DIFF
--- a/repositories.py
+++ b/repositories.py
@@ -46,7 +46,7 @@ GROUP_REPOS = [
         "FS",
         ["https://github.com/Lukski175/MiniTwit-FS"],
         "http(s)://<TBA>/<FrontEndURL>",
-        "http(s)://<TBA>/<APIURL>",
+        "https://minitwit-api-5ezat.ondigitalocean.app",
     ],
     [
         "group i",


### PR DESCRIPTION
I see that our URL is different from other groups IP format, let me know if this doesn't work for the simulator