### PR TITLE
Update group i URLs to use port 80

### DIFF
--- a/repositories.py
+++ b/repositories.py
@@ -52,8 +52,8 @@ GROUP_REPOS = [
         "group i",
         "CloudMorphers",
         ["https://github.com/CloudMorphers/minitwit"],
-        "http://67.207.72.20:8080",
-        "http://67.207.72.20:8080/api",
+        "http://67.207.72.20",
+        "http://67.207.72.20/api",
     ],
     [
         "group j",


### PR DESCRIPTION
We have set up an Nginx reverse proxy on port 80. Currently, communication can still be made to the Kestrel server on port 8080, but we would like to block incoming traffic on port 8080, and only allow traffic through the reverse proxy.