### PR TITLE
Group L - Report Release URL

### DIFF
--- a/final_report_urls.py
+++ b/final_report_urls.py
@@ -67,9 +67,9 @@ REPORT_URLS = [
     ],
     [
         "group l",
-        "<name>",
+        "the happy group",
         # Report Release URL:
-        "https://github.com/<gh_id>/<proj_id>/archive/refs/tags/<version_tag>.zip",
+        "https://github.com/Only-Smiles/DevOps-2025/archive/refs/tags/v2025.05.29.01.zip"
     ],
     [
         "group m",

--- a/misc_urls.py
+++ b/misc_urls.py
@@ -97,7 +97,7 @@ GROUP_URLS = [
     ],
     [
         "group l",
-        "<name>",
+        "the happy group",
         # Monitoring URL:
         "http://139.59.204.182:3000/",
         # Logging URL:


### PR DESCRIPTION
Also added group name to `misc_urls.py` as I realised it was missing.